### PR TITLE
Switch to JINJA_ENVIRONMENT for pelican>=3.7.0

### DIFF
--- a/plugins/jinja2content/jinja2content.py
+++ b/plugins/jinja2content/jinja2content.py
@@ -10,15 +10,13 @@ def execjinja2(instance):
     if type(instance) in (contents.Article, contents.Page):
         base_path = os.path.dirname(os.path.abspath(__file__))
         jinja2_env = Environment(
-            trim_blocks=True,
-            lstrip_blocks=True,
             loader=ChoiceLoader([
                 FileSystemLoader(
                     os.path.join(base_path, instance.settings['THEME'],
                                  'templates')
                 ),
             ]),
-            extensions=instance.settings['JINJA_EXTENSIONS'],
+            **instance.settings['JINJA_ENVIRONMENT']
         )
         jinja2_template = jinja2_env.from_string(instance._content)
 


### PR DESCRIPTION
See [this commit](https://github.com/getpelican/pelican/commit/335c40d23eb8b74bd6188646468a75f2c9c67dcd) introduced in pelican 3.7.0 which replaced `JINJA_EXTENSIONS` with a more flexible `JINJA_ENVIRONMENT` setting for constructing a Jinja [`Environment`](http://jinja.pocoo.org/docs/dev/api/#jinja2.Environment).

conda-forge is currently serving pelican 3.7.0, so the installation instructions don't really need to change.

I'm submitting this as a PR so building doesn't break for @moorepants, who needs to `conda update pelican` :)