### PR TITLE
Ensure builds fail on errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
   - ls
 script:
   - set -e
-  - pelican -s publishconf.py
+  - pelican --verbose --fatal errors -s publishconf.py
   - if [[ -z "$TRAVIS_TAG" ]]; then
       DEPLOY_DIR=".";
     else


### PR DESCRIPTION
It may be that Pelican 4 no longer fails and exits with 0 if there is an error. So I've enabled the flag to ensure this happens so we can prevent broken builds from going into master (better).