### PR TITLE
Fix career fair link and cornell resume info link

### DIFF
--- a/content/pages/resources.rst
+++ b/content/pages/resources.rst
@@ -104,21 +104,21 @@ Getting a Job
 
 `Internship and Career Center`_
    Submit your resume and look for job postings.
-`Engineering Career Fairs`_
+`Internship and Career Fairs`_
    UCD hosts several of these every year.
 `UC Davis Corporate Relations`_
    Get into the specialized engineering student recruitment database, Eureka!,
    visit a company on a tour, etc.
 
 .. _Internship and Career Center: https://icc.ucdavis.edu/
-.. _Engineering Career Fairs: https://icc.ucdavis.edu/services/fairs/engineering.htm
+.. _Internship and Career Fairs: https://icc.ucdavis.edu/services/fair/prepare/attendees/
 .. _UC Davis Corporate Relations: http://engineering.ucdavis.edu/corporate-relations/student-recruitment/
 
 Resume Information
 ------------------
 
 - UCD Internship and Career Center's tips: https://icc.ucdavis.edu/materials/resume/
-- Tips from Cornell University: https://research.engineering.cornell.edu/resources/career_services/students/resumes.cfm
+- Tips from Cornell University: https://www.career.cornell.edu/story/resumes/parts.cfm
 - Electronic resume and networking: LinkedIn https://www.linkedin.com
 
 Out-of-the-box Resume Websites


### PR DESCRIPTION
Career fair link now takes students to page showing career fair dates and links on that page can take students to a list of attendees of each career fair. Cornell resume link is to page describing the main components of a resume.